### PR TITLE
Auto-scale image plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Window title can be set at construction time (#11)
 * Adds interface `InputHandler` for handling user input (#12)
 * Adds `Controls` plot and input handler for controlling simulation speed and pause via GUI or keyboard (#12)
+* `Image` and `ImageRGB` auto-scale when no explicit scale is given (#13)
+* Adds Method `window.CalcScale` to calculate scaling like in `Image` and `ImageRGB` (#13)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Adds interface `InputHandler` for handling user input (#12)
 * Adds `Controls` plot and input handler for controlling simulation speed and pause via GUI or keyboard (#12)
 * `Image` and `ImageRGB` auto-scale when no explicit scale is given (#13)
-* Adds Method `window.CalcScale` to calculate scaling like in `Image` and `ImageRGB` (#13)
+* Adds Method `window.Scale` to calculate scaling like in `Image` and `ImageRGB` (#13)
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *Arche Pixel* provides OpenGL graphics and live plots for the [Arche](https://github.com/mlange-42/arche) Entity Component System (ECS) using the [Pixel](https://github.com/faiface/pixel) game engine.
 
-![Screenshot](https://user-images.githubusercontent.com/44003176/229729236-8b5adabb-19fe-43a9-b2f6-ff7f005cb149.png)
+![Screenshot](https://user-images.githubusercontent.com/44003176/230742745-d7adee93-8c70-4e32-b031-7258185aa2b1.png)
 
 ## Installation
 

--- a/plot/image.go
+++ b/plot/image.go
@@ -7,12 +7,13 @@ import (
 	"github.com/faiface/pixel/pixelgl"
 	"github.com/mazznoer/colorgrad"
 	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche-pixel/window"
 	"github.com/mlange-42/arche/ecs"
 )
 
 // Image plot drawer.
 type Image struct {
-	Scale    float64            // Spatial scaling: cell size in screen pixels. Optional, default 1.
+	Scale    float64            // Spatial scaling: cell size in screen pixels. Optional, default auto.
 	Observer observer.Matrix    // Observer providing 2D matrix or grid data.
 	Colors   colorgrad.Gradient // Colors for mapping values.
 	Min      float64            // Minimum value for color mapping. Optional.
@@ -25,9 +26,6 @@ type Image struct {
 func (i *Image) Initialize(w *ecs.World, win *pixelgl.Window) {
 	i.Observer.Initialize(w)
 
-	if i.Scale <= 0 {
-		i.Scale = 1
-	}
 	if i.Min == 0 && i.Max == 0 {
 		i.Max = 1
 	}
@@ -52,8 +50,16 @@ func (i *Image) Draw(w *ecs.World, win *pixelgl.Window) {
 		i.picture.Pix[j] = i.valueToColor(values[j])
 	}
 
+	scale := i.Scale
+	if i.Scale <= 0 {
+		scale = window.CalcScale(win, i.picture.Rect.W(), i.picture.Rect.H())
+	}
+
 	sprite := pixel.NewSprite(i.picture, i.picture.Bounds())
-	sprite.Draw(win, pixel.IM.Moved(pixel.V(i.picture.Rect.W()/2.0, i.picture.Rect.H()/2.0)).Scaled(pixel.Vec{}, i.Scale))
+	sprite.Draw(win,
+		pixel.IM.Moved(pixel.V(i.picture.Rect.W()/2.0, i.picture.Rect.H()/2.0)).
+			Scaled(pixel.Vec{}, scale),
+	)
 }
 
 func (i *Image) valueToColor(v float64) color.RGBA {

--- a/plot/image.go
+++ b/plot/image.go
@@ -52,7 +52,7 @@ func (i *Image) Draw(w *ecs.World, win *pixelgl.Window) {
 
 	scale := i.Scale
 	if i.Scale <= 0 {
-		scale = window.CalcScale(win, i.picture.Rect.W(), i.picture.Rect.H())
+		scale = window.Scale(win, i.picture.Rect.W(), i.picture.Rect.H())
 	}
 
 	sprite := pixel.NewSprite(i.picture, i.picture.Bounds())

--- a/plot/rgb_image.go
+++ b/plot/rgb_image.go
@@ -98,7 +98,7 @@ func (i *ImageRGB) Draw(w *ecs.World, win *pixelgl.Window) {
 
 	scale := i.Scale
 	if i.Scale <= 0 {
-		scale = window.CalcScale(win, i.picture.Rect.W(), i.picture.Rect.H())
+		scale = window.Scale(win, i.picture.Rect.W(), i.picture.Rect.H())
 	}
 
 	sprite := pixel.NewSprite(i.picture, i.picture.Bounds())

--- a/plot/rgb_image.go
+++ b/plot/rgb_image.go
@@ -6,12 +6,13 @@ import (
 	"github.com/faiface/pixel"
 	"github.com/faiface/pixel/pixelgl"
 	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche-pixel/window"
 	"github.com/mlange-42/arche/ecs"
 )
 
 // ImageRGB plot drawer.
 type ImageRGB struct {
-	Scale     float64           // Spatial scaling: cell size in screen pixels. Optional, default 1.
+	Scale     float64           // Spatial scaling: cell size in screen pixels. Optional, default auto.
 	Observers []observer.Matrix // Observers for the red, green and blue channel. Elements can be nil.
 	Min       []float64         // Minimum value for channel color mapping. Optional, default [0, 0, 0].
 	Max       []float64         // Maximum value for channel color mapping. Optional, default [1, 1, 1].
@@ -44,9 +45,6 @@ func (i *ImageRGB) Initialize(w *ecs.World, win *pixelgl.Window) {
 		panic("needs an observer for at least one channel")
 	}
 
-	if i.Scale <= 0 {
-		i.Scale = 1
-	}
 	if i.Min == nil {
 		i.Min = []float64{0, 0, 0}
 	}
@@ -98,8 +96,16 @@ func (i *ImageRGB) Draw(w *ecs.World, win *pixelgl.Window) {
 		i.picture.Pix[j] = i.valuesToColor(values[0], values[1], values[2])
 	}
 
+	scale := i.Scale
+	if i.Scale <= 0 {
+		scale = window.CalcScale(win, i.picture.Rect.W(), i.picture.Rect.H())
+	}
+
 	sprite := pixel.NewSprite(i.picture, i.picture.Bounds())
-	sprite.Draw(win, pixel.IM.Moved(pixel.V(i.picture.Rect.W()/2.0, i.picture.Rect.H()/2.0)).Scaled(pixel.Vec{}, i.Scale))
+	sprite.Draw(win,
+		pixel.IM.Moved(pixel.V(i.picture.Rect.W()/2.0, i.picture.Rect.H()/2.0)).
+			Scaled(pixel.Vec{}, scale),
+	)
 }
 
 func (i *ImageRGB) valuesToColor(r, g, b float64) color.RGBA {

--- a/plot/rgb_image_test.go
+++ b/plot/rgb_image_test.go
@@ -24,7 +24,6 @@ func ExampleImageRGB() {
 	// See below for the implementation of the CallbackMatrixObserver.
 	m.AddUISystem((&window.Window{}).
 		With(&plot.ImageRGB{
-			Scale: 4,
 			Observers: []observer.Matrix{
 				&CallbackMatrixObserver{Callback: func(i, j int) float64 { return float64(i) / 240 }},
 				&CallbackMatrixObserver{Callback: func(i, j int) float64 { return math.Sin(0.1 * float64(i)) }},

--- a/plot/util.go
+++ b/plot/util.go
@@ -3,6 +3,7 @@ package plot
 import (
 	"math"
 
+	"github.com/faiface/pixel"
 	"github.com/faiface/pixel/text"
 	"golang.org/x/image/font/basicfont"
 	"gonum.org/v1/plot/vg"
@@ -13,6 +14,12 @@ var font = text.NewAtlas(basicfont.Face7x13, text.ASCII)
 
 var preferredTicks = []float64{1, 2, 5, 10}
 var preferredTps = []float64{0, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200, 250, 500, 750, 1000, 2000, 5000, 10000}
+
+// Vec is a 2D vector
+type Vec = pixel.Vec
+
+// V returns a new [Vec]
+func V(x, y float64) Vec { return pixel.V(x, y) }
 
 func calcScaleCorrection() float64 {
 	width := 100.0

--- a/window/util.go
+++ b/window/util.go
@@ -1,0 +1,14 @@
+package window
+
+import (
+	"math"
+
+	"github.com/faiface/pixel/pixelgl"
+)
+
+// CalcScale calculates the drawing scale for fitting a source region into a window's canvas.
+func CalcScale(win *pixelgl.Window, srcWidth, srcHeight float64) float64 {
+	winWidth, winHeight := win.Canvas().Bounds().W(), win.Canvas().Bounds().H()
+	scX, scY := winWidth/float64(srcWidth), winHeight/float64(srcHeight)
+	return math.Min(scX, scY)
+}

--- a/window/util.go
+++ b/window/util.go
@@ -6,8 +6,8 @@ import (
 	"github.com/faiface/pixel/pixelgl"
 )
 
-// CalcScale calculates the drawing scale for fitting a source region into a window's canvas.
-func CalcScale(win *pixelgl.Window, srcWidth, srcHeight float64) float64 {
+// Scale calculates the drawing scale for fitting a source region into a window's canvas.
+func Scale(win *pixelgl.Window, srcWidth, srcHeight float64) float64 {
 	winWidth, winHeight := win.Canvas().Bounds().W(), win.Canvas().Bounds().H()
 	scX, scY := winWidth/float64(srcWidth), winHeight/float64(srcHeight)
 	return math.Min(scX, scY)


### PR DESCRIPTION
- `Image` and `ImageRGB` auto-scale when no explicit scale is given
- Adds Method `window.Scale` to calculate scaling like in `Image` and `ImageRGB`