### PR TITLE
Shorten field names for Bounds width and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `Drawer` interface has method `Update(w *ecs.World)` (#8)
 * All plots are `Drawer` instead of `UISystem`, and are added to a `Window` (#8)
 * Upgrade to `arche-model` v0.0.4 (#9, #10)
+* Fields of `Bounds` renamed from `Width` and `Height` to `W` and `H` (#15)
 
 ### Features
 

--- a/window/window.go
+++ b/window/window.go
@@ -34,10 +34,10 @@ type Drawer interface {
 
 // Bounds define a bounding box for a window.
 type Bounds struct {
-	X      int
-	Y      int
-	Width  int
-	Height int
+	X int // X position
+	Y int // Y position
+	W int // Width
+	H int // Height
 }
 
 // B created a new Bounds object.
@@ -73,18 +73,18 @@ func (w *Window) Initialize(world *ecs.World) {}
 
 // InitializeUI the window system.
 func (w *Window) InitializeUI(world *ecs.World) {
-	if w.Bounds.Width <= 0 {
-		w.Bounds.Width = 1024
+	if w.Bounds.W <= 0 {
+		w.Bounds.W = 1024
 	}
-	if w.Bounds.Height <= 0 {
-		w.Bounds.Height = 768
+	if w.Bounds.H <= 0 {
+		w.Bounds.H = 768
 	}
 	if w.Title == "" {
 		w.Title = "Arche"
 	}
 	cfg := pixelgl.WindowConfig{
 		Title:     w.Title,
-		Bounds:    pixel.R(0, 0, float64(w.Bounds.Width), float64(w.Bounds.Height)),
+		Bounds:    pixel.R(0, 0, float64(w.Bounds.W), float64(w.Bounds.H)),
 		Position:  pixel.V(float64(w.Bounds.X), float64(w.Bounds.Y)),
 		Resizable: true,
 	}


### PR DESCRIPTION
Fields of `Bounds` renamed from `Width` and `Height` to `W` and `H`