### PR TITLE
Fix jumping X axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 ### Other
 
-* Plots use mono-spaced font and fixed tick label axis padding to avoid jumping y axis(#26)
+* Plots use mono-spaced font and fixed tick label axis padding, to avoid jumping y axis (#26)
+* Remove the last tick label from the x axis if close to the right margin, to avoid jumping x axis (#29)
 
 ## [[v0.2.0]](https://github.com/mlange-42/arche-pixel/compare/v0.1.0...v0.2.0)
 

--- a/plot/bars.go
+++ b/plot/bars.go
@@ -57,10 +57,12 @@ func (b *Bars) Draw(w *ecs.World, win *pixelgl.Window) {
 	c := vgimg.New(vg.Points(width*b.scale)-10, vg.Points(height*b.scale)-10)
 
 	p := plot.New()
+
 	p.X.Tick.Label.Font.Size = 12
+	p.X.Tick.Label.Font.Variant = "Mono"
+
 	p.Y.Tick.Label.Font.Size = 12
 	p.Y.Tick.Label.Font.Variant = "Mono"
-	p.X.Tick.Label.Font.Variant = "Mono"
 	p.Y.Tick.Marker = paddedTicks{}
 
 	bw := 0.5 * (width - 50) / float64(len(b.series))

--- a/plot/lines.go
+++ b/plot/lines.go
@@ -93,10 +93,13 @@ func (l *Lines) Draw(w *ecs.World, win *pixelgl.Window) {
 	c := vgimg.New(vg.Points(width*l.scale)-10, vg.Points(height*l.scale)-10)
 
 	p := plot.New()
+
 	p.X.Tick.Label.Font.Size = 12
+	p.X.Tick.Label.Font.Variant = "Mono"
+	p.X.Tick.Marker = removeLastTicks{}
+
 	p.Y.Tick.Label.Font.Size = 12
 	p.Y.Tick.Label.Font.Variant = "Mono"
-	p.X.Tick.Label.Font.Variant = "Mono"
 	p.Y.Tick.Marker = paddedTicks{}
 
 	p.Legend = plot.NewLegend()

--- a/plot/scatter.go
+++ b/plot/scatter.go
@@ -107,10 +107,13 @@ func (s *Scatter) Draw(w *ecs.World, win *pixelgl.Window) {
 	c := vgimg.New(vg.Points(width*s.scale)-10, vg.Points(height*s.scale)-10)
 
 	p := plot.New()
+
 	p.X.Tick.Label.Font.Size = 12
+	p.X.Tick.Label.Font.Variant = "Mono"
+	p.X.Tick.Marker = removeLastTicks{}
+
 	p.Y.Tick.Label.Font.Size = 12
 	p.Y.Tick.Label.Font.Variant = "Mono"
-	p.X.Tick.Label.Font.Variant = "Mono"
 	p.Y.Tick.Marker = paddedTicks{}
 
 	p.Legend = plot.NewLegend()

--- a/plot/time_series.go
+++ b/plot/time_series.go
@@ -70,10 +70,13 @@ func (t *TimeSeries) Draw(w *ecs.World, win *pixelgl.Window) {
 	c := vgimg.New(vg.Points(width*t.scale)-10, vg.Points(height*t.scale)-10)
 
 	p := plot.New()
+
 	p.X.Tick.Label.Font.Size = 12
+	p.X.Tick.Label.Font.Variant = "Mono"
+	p.X.Tick.Marker = removeLastTicks{}
+
 	p.Y.Tick.Label.Font.Size = 12
 	p.Y.Tick.Label.Font.Variant = "Mono"
-	p.X.Tick.Label.Font.Variant = "Mono"
 	p.Y.Tick.Marker = paddedTicks{}
 
 	p.Legend = plot.NewLegend()

--- a/plot/util.go
+++ b/plot/util.go
@@ -79,6 +79,7 @@ func calcTps(curr float64, increase bool) float64 {
 	return 0
 }
 
+// Left-pads tick labels to avoid jumping Y axis.
 type paddedTicks struct {
 	plot.DefaultTicks
 }
@@ -87,6 +88,25 @@ func (t paddedTicks) Ticks(min, max float64) []plot.Tick {
 	ticks := t.DefaultTicks.Ticks(min, max)
 	for i := 0; i < len(ticks); i++ {
 		ticks[i].Label = fmt.Sprintf("%*s", 10, ticks[i].Label)
+	}
+	return ticks
+}
+
+// Removes the last tick label to avoid jumping X axis.
+type removeLastTicks struct {
+	plot.DefaultTicks
+}
+
+func (t removeLastTicks) Ticks(min, max float64) []plot.Tick {
+	ticks := t.DefaultTicks.Ticks(min, max)
+	for i := 0; i < len(ticks); i++ {
+		tick := &ticks[i]
+		if tick.IsMinor() {
+			continue
+		}
+		if tick.Value > max-(0.05*(max-min)) {
+			tick.Label = ""
+		}
 	}
 	return ticks
 }


### PR DESCRIPTION
Remove the last tick label from the x axis if close to the right margin, to avoid jumping x axis