### PR TITLE
Contour plots, heat maps and vector fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Drawer `plot.Lines` for plotting table observer data, with a line series per column, and a common X column (#22)
 * Drawer `plot.Scatter` for plotting table observer data as scatter plots. Supports multiple observers and multiple series per observer (#25)
 * Drawer `plot.Bars` for plotting row observer data as bar chart (#27)
+* Drawer `plot.Contour` for plotting grid data as contours (#32)
+* Drawer `plot.HeatMap` for plotting grid data as heat maps (#32)
 * Plot title, axes labels and axes limits can be configured for plots (optional) (#30)
 * Optional selection of columns in bar and time series plots (#30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## [[v0.3.0]](https://github.com/mlange-42/arche-pixel/compare/v0.2.0...v0.3.0)
 
+### Breaking changes
+
+* Drawer `ImageRGB` uses one `MatrixLayers` observers instead of three `Matrix` observers (#31)
+
 ### Features
 
 * Drawer `plot.Lines` for plotting table observer data, with a line series per column, and a common X column (#22)
 * Drawer `plot.Scatter` for plotting table observer data as scatter plots. Supports multiple observers and multiple series per observer (#25)
 * Drawer `plot.Bars` for plotting row observer data as bar chart (#27)
-* Drawer `plot.Contour` for plotting grid data as contours (#32)
-* Drawer `plot.HeatMap` for plotting grid data as heat maps (#32)
+* Drawer `plot.Contour` for plotting grid data as contours (#31)
+* Drawer `plot.HeatMap` for plotting grid data as heat maps (#31)
+* Drawer `plot.Field` for plotting 2D vector fields (#31)
 * Plot title, axes labels and axes limits can be configured for plots (optional) (#30)
 * Optional selection of columns in bar and time series plots (#30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-* Drawer `ImageRGB` uses one `MatrixLayers` observers instead of three `Matrix` observers (#31)
+* Drawer `plot.ImageRGB` uses one `MatrixLayers` observers instead of three `Matrix` observers (#31)
 
 ### Features
 
@@ -16,6 +16,7 @@
 * Drawer `plot.Field` for plotting 2D vector fields (#31)
 * Plot title, axes labels and axes limits can be configured for plots (optional) (#30)
 * Optional selection of columns in bar and time series plots (#30)
+* Drawers `plot.ImageRGB` and `plot.Field` can freely assign layers to channels (#31)
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Features
 
 * Free 2D drawing using a convenient OpenGL interface.
-* Live plots using unified observers (time series, line, bar and scatter plots).
+* Live plots using unified observers (time series, line, bar, scatter and contour plots).
 * ECS engine monitor for detailed performance statistics.
 * Entity inspector for debugging and inspection.
 * Simulation controls to pause or limit speed interactively.

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/faiface/pixel v0.10.0
 	github.com/mazznoer/colorgrad v0.9.1
 	github.com/mlange-42/arche v0.7.0
-	github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8
+	github.com/mlange-42/arche-model v0.2.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/image v0.5.0
 	gonum.org/v1/plot v0.12.0
 )
+
+replace github.com/mlange-42/arche-model v0.2.0 => ../arche-model
 
 require (
 	git.sr.ht/~sbinet/gg v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/faiface/pixel v0.10.0
 	github.com/mazznoer/colorgrad v0.9.1
 	github.com/mlange-42/arche v0.7.0
-	github.com/mlange-42/arche-model v0.2.0
+	github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/image v0.5.0
 	gonum.org/v1/plot v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,11 @@ require (
 	github.com/faiface/pixel v0.10.0
 	github.com/mazznoer/colorgrad v0.9.1
 	github.com/mlange-42/arche v0.7.0
-	github.com/mlange-42/arche-model v0.2.0
+	github.com/mlange-42/arche-model v0.2.1-0.20230418144552-c3a825aab39e
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/image v0.5.0
 	gonum.org/v1/plot v0.12.0
 )
-
-replace github.com/mlange-42/arche-model v0.2.0 => ../arche-model
 
 require (
 	git.sr.ht/~sbinet/gg v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/mazznoer/csscolorparser v0.1.2 h1:/UBHuQg792ePmGFzTQAC9u+XbFr7/HzP/Gj
 github.com/mazznoer/csscolorparser v0.1.2/go.mod h1:Aj22+L/rYN/Y6bj3bYqO3N6g1dtdHtGfQ32xZ5PJQic=
 github.com/mlange-42/arche v0.7.0 h1:66HmSfVQFIYx7PyQtOjmWuGCzBX0fhefYqpDkWpyy6E=
 github.com/mlange-42/arche v0.7.0/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
+github.com/mlange-42/arche-model v0.2.1-0.20230418144552-c3a825aab39e h1:b/I8XBOCWBz+Fs8eerMMxytxjNSnCEX8xYoIraHqBVw=
+github.com/mlange-42/arche-model v0.2.1-0.20230418144552-c3a825aab39e/go.mod h1:VSOVJBHjw6gQm9B1vOVLsteFtXvZgJmNCOKQoh1jqYc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/mazznoer/csscolorparser v0.1.2 h1:/UBHuQg792ePmGFzTQAC9u+XbFr7/HzP/Gj
 github.com/mazznoer/csscolorparser v0.1.2/go.mod h1:Aj22+L/rYN/Y6bj3bYqO3N6g1dtdHtGfQ32xZ5PJQic=
 github.com/mlange-42/arche v0.7.0 h1:66HmSfVQFIYx7PyQtOjmWuGCzBX0fhefYqpDkWpyy6E=
 github.com/mlange-42/arche v0.7.0/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
-github.com/mlange-42/arche-model v0.2.0 h1:JrGKLIGDMKumsYeddKw9S5RlUk0OOzUQH7GkkZGj1YM=
-github.com/mlange-42/arche-model v0.2.0/go.mod h1:VSOVJBHjw6gQm9B1vOVLsteFtXvZgJmNCOKQoh1jqYc=
+github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8 h1:IcyL2WXxyVEabya/8C/aiG39ri8x/x3BoTFwfPjFWQs=
+github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8/go.mod h1:VSOVJBHjw6gQm9B1vOVLsteFtXvZgJmNCOKQoh1jqYc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/mazznoer/csscolorparser v0.1.2 h1:/UBHuQg792ePmGFzTQAC9u+XbFr7/HzP/Gj
 github.com/mazznoer/csscolorparser v0.1.2/go.mod h1:Aj22+L/rYN/Y6bj3bYqO3N6g1dtdHtGfQ32xZ5PJQic=
 github.com/mlange-42/arche v0.7.0 h1:66HmSfVQFIYx7PyQtOjmWuGCzBX0fhefYqpDkWpyy6E=
 github.com/mlange-42/arche v0.7.0/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
-github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8 h1:IcyL2WXxyVEabya/8C/aiG39ri8x/x3BoTFwfPjFWQs=
-github.com/mlange-42/arche-model v0.2.1-0.20230418101916-a143644233d8/go.mod h1:VSOVJBHjw6gQm9B1vOVLsteFtXvZgJmNCOKQoh1jqYc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=

--- a/plot/contour.go
+++ b/plot/contour.go
@@ -1,0 +1,105 @@
+package plot
+
+import (
+	"image/color"
+
+	"github.com/faiface/pixel"
+	"github.com/faiface/pixel/pixelgl"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche/ecs"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/palette"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
+	"gonum.org/v1/plot/vg/draw"
+	"gonum.org/v1/plot/vg/vgimg"
+)
+
+// Contour plot drawer.
+//
+// Plots a grid as a contours.
+// For large grids, this is relatively slow.
+// Consider using [Image] instead.ü
+type Contour struct {
+	Observer observer.Grid   // Observers providing a Grid for contours.
+	Levels   []float64       // Levels for iso lines. Optional.
+	Palette  palette.Palette // Color palette. Optional.
+	Labels   Labels          // Labels for plot and axes. Optional.
+
+	data  plotGrid
+	scale float64
+}
+
+// Initialize the drawer.
+func (s *Contour) Initialize(w *ecs.World, win *pixelgl.Window) {
+	s.Observer.Initialize(w)
+	s.scale = calcScaleCorrection()
+}
+
+// Update the drawer.
+func (s *Contour) Update(w *ecs.World) {
+	s.Observer.Update(w)
+
+	s.data = plotGrid{
+		Grid: s.Observer,
+	}
+}
+
+// UpdateInputs handles input events of the previous frame update.
+func (s *Contour) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
+
+// Draw the drawer.
+func (s *Contour) Draw(w *ecs.World, win *pixelgl.Window) {
+	s.updateData(w)
+
+	width := win.Canvas().Bounds().W()
+	height := win.Canvas().Bounds().H()
+
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	c := vgimg.New(vg.Points(width*s.scale)-10, vg.Points(height*s.scale)-10)
+
+	p := plot.New()
+	setLabels(p, s.Labels)
+
+	p.X.Tick.Marker = removeLastTicks{}
+
+	//contours := plotter.NewContour(&s.data, s.Levels, s.Palette)
+	cols := s.Palette.Colors()
+	min := 0.0
+	max := 1.0
+	if len(s.Levels) > 0 {
+		min = s.Levels[0]
+		max = s.Levels[len(s.Levels)-1]
+	} else {
+		s.Levels = []float64{0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99}
+	}
+
+	contours := &plotter.Contour{
+		GridXYZ:    &s.data,
+		Levels:     s.Levels,
+		LineStyles: []draw.LineStyle{plotter.DefaultLineStyle},
+		Palette:    s.Palette,
+		Underflow:  cols[0],
+		Overflow:   cols[len(cols)-1],
+		Min:        min,
+		Max:        max,
+	}
+
+	p.Add(contours)
+
+	win.Clear(color.White)
+	p.Draw(draw.New(c))
+
+	img := c.Image()
+	picture := pixel.PictureDataFromImage(img)
+
+	sprite := pixel.NewSprite(picture, picture.Bounds())
+	sprite.Draw(win, pixel.IM.Moved(pixel.V(picture.Rect.W()/2.0+5, picture.Rect.H()/2.0+5)))
+}
+
+func (s *Contour) updateData(w *ecs.World) {
+	s.data.Values = s.Observer.Values(w)
+}

--- a/plot/contour.go
+++ b/plot/contour.go
@@ -1,6 +1,7 @@
 package plot
 
 import (
+	"fmt"
 	"image/color"
 
 	"github.com/faiface/pixel"
@@ -21,36 +22,37 @@ import (
 // For large grids, this is relatively slow.
 // Consider using [Image] instead.ü
 type Contour struct {
-	Observer observer.Grid   // Observers providing a Grid for contours.
-	Levels   []float64       // Levels for iso lines. Optional.
-	Palette  palette.Palette // Color palette. Optional.
-	Labels   Labels          // Labels for plot and axes. Optional.
+	Observer   observer.Grid   // Observers providing a Grid for contours.
+	Levels     []float64       // Levels for iso lines. Optional.
+	Palette    palette.Palette // Color palette. Optional.
+	Labels     Labels          // Labels for plot and axes. Optional.
+	HideLegend bool            // Hides the legend.
 
 	data  plotGrid
 	scale float64
 }
 
 // Initialize the drawer.
-func (s *Contour) Initialize(w *ecs.World, win *pixelgl.Window) {
-	s.Observer.Initialize(w)
-	s.scale = calcScaleCorrection()
+func (c *Contour) Initialize(w *ecs.World, win *pixelgl.Window) {
+	c.Observer.Initialize(w)
+	c.scale = calcScaleCorrection()
 }
 
 // Update the drawer.
-func (s *Contour) Update(w *ecs.World) {
-	s.Observer.Update(w)
+func (c *Contour) Update(w *ecs.World) {
+	c.Observer.Update(w)
 
-	s.data = plotGrid{
-		Grid: s.Observer,
+	c.data = plotGrid{
+		Grid: c.Observer,
 	}
 }
 
 // UpdateInputs handles input events of the previous frame update.
-func (s *Contour) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
+func (c *Contour) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
 
 // Draw the drawer.
-func (s *Contour) Draw(w *ecs.World, win *pixelgl.Window) {
-	s.updateData(w)
+func (c *Contour) Draw(w *ecs.World, win *pixelgl.Window) {
+	c.updateData(w)
 
 	width := win.Canvas().Bounds().W()
 	height := win.Canvas().Bounds().H()
@@ -59,47 +61,96 @@ func (s *Contour) Draw(w *ecs.World, win *pixelgl.Window) {
 		return
 	}
 
-	c := vgimg.New(vg.Points(width*s.scale)-10, vg.Points(height*s.scale)-10)
+	canvas := vgimg.New(vg.Points(width*c.scale)-10, vg.Points(height*c.scale)-10)
 
 	p := plot.New()
-	setLabels(p, s.Labels)
+	setLabels(p, c.Labels)
 
 	p.X.Tick.Marker = removeLastTicks{}
 
 	//contours := plotter.NewContour(&s.data, s.Levels, s.Palette)
-	cols := s.Palette.Colors()
+	cols := c.Palette.Colors()
 	min := 0.0
 	max := 1.0
-	if len(s.Levels) > 0 {
-		min = s.Levels[0]
-		max = s.Levels[len(s.Levels)-1]
+	if len(c.Levels) > 0 {
+		min = c.Levels[0]
+		max = c.Levels[len(c.Levels)-1]
 	} else {
-		s.Levels = []float64{0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99}
+		c.Levels = []float64{0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99}
 	}
 
-	contours := &plotter.Contour{
-		GridXYZ:    &s.data,
-		Levels:     s.Levels,
+	contours := plotter.Contour{
+		GridXYZ:    &c.data,
+		Levels:     c.Levels,
 		LineStyles: []draw.LineStyle{plotter.DefaultLineStyle},
-		Palette:    s.Palette,
+		Palette:    c.Palette,
 		Underflow:  cols[0],
 		Overflow:   cols[len(cols)-1],
 		Min:        min,
 		Max:        max,
 	}
 
-	p.Add(contours)
+	if !c.HideLegend {
+		p.Legend = plot.NewLegend()
+		p.Legend.TextStyle.Font.Variant = "Mono"
+		c.populateLegend(&p.Legend, &contours)
+	}
+
+	p.Add(&contours)
 
 	win.Clear(color.White)
-	p.Draw(draw.New(c))
+	p.Draw(draw.New(canvas))
 
-	img := c.Image()
+	img := canvas.Image()
 	picture := pixel.PictureDataFromImage(img)
 
 	sprite := pixel.NewSprite(picture, picture.Bounds())
 	sprite.Draw(win, pixel.IM.Moved(pixel.V(picture.Rect.W()/2.0+5, picture.Rect.H()/2.0+5)))
 }
 
-func (s *Contour) updateData(w *ecs.World) {
-	s.data.Values = s.Observer.Values(w)
+func (c *Contour) updateData(w *ecs.World) {
+	c.data.Values = c.Observer.Values(w)
+}
+
+func (c *Contour) populateLegend(legend *plot.Legend, contours *plotter.Contour) {
+	var pal []color.Color
+	if c.Palette != nil {
+		pal = c.Palette.Colors()
+	}
+	ps := float64(len(pal)-1) / (c.Levels[len(c.Levels)-1] - c.Levels[0])
+	if len(c.Levels) == 1 {
+		ps = 0
+	}
+	for i := len(c.Levels) - 1; i >= 0; i-- {
+		z := c.Levels[i]
+		var col color.Color
+		switch {
+		case z < contours.Min:
+			col = contours.Underflow
+		case z > contours.Max:
+			col = contours.Overflow
+		case len(pal) == 0:
+			col = contours.Underflow
+		default:
+			col = pal[int((z-c.Levels[0])*ps+0.5)] // Apply palette scaling.
+		}
+		legend.Add(fmt.Sprintf("%f", z), colorThumbnailer{col})
+	}
+}
+
+// colorThumbnailer implements the Thumbnailer interface.
+type colorThumbnailer struct {
+	color color.Color
+}
+
+// Thumbnail satisfies the plot.Thumbnailer interface.
+func (t colorThumbnailer) Thumbnail(c *draw.Canvas) {
+	pts := []vg.Point{
+		{X: c.Min.X, Y: c.Min.Y},
+		{X: c.Min.X, Y: c.Max.Y},
+		{X: c.Max.X, Y: c.Max.Y},
+		{X: c.Max.X, Y: c.Min.Y},
+	}
+	poly := c.ClipPolygonY(pts)
+	c.FillPolygon(t.color, poly)
 }

--- a/plot/contour.go
+++ b/plot/contour.go
@@ -20,7 +20,7 @@ import (
 //
 // Plots a grid as a contours.
 // For large grids, this is relatively slow.
-// Consider using [Image] instead.ü
+// Consider using [Image] instead.
 type Contour struct {
 	Observer   observer.Grid   // Observers providing a Grid for contours.
 	Levels     []float64       // Levels for iso lines. Optional.
@@ -35,16 +35,15 @@ type Contour struct {
 // Initialize the drawer.
 func (c *Contour) Initialize(w *ecs.World, win *pixelgl.Window) {
 	c.Observer.Initialize(w)
+	c.data = plotGrid{
+		Grid: c.Observer,
+	}
 	c.scale = calcScaleCorrection()
 }
 
 // Update the drawer.
 func (c *Contour) Update(w *ecs.World) {
 	c.Observer.Update(w)
-
-	c.data = plotGrid{
-		Grid: c.Observer,
-	}
 }
 
 // UpdateInputs handles input events of the previous frame update.
@@ -68,7 +67,6 @@ func (c *Contour) Draw(w *ecs.World, win *pixelgl.Window) {
 
 	p.X.Tick.Marker = removeLastTicks{}
 
-	//contours := plotter.NewContour(&s.data, s.Levels, s.Palette)
 	cols := c.Palette.Colors()
 	min := 0.0
 	max := 1.0

--- a/plot/contour_test.go
+++ b/plot/contour_test.go
@@ -21,11 +21,9 @@ func ExampleContour() {
 	m.AddUISystem(
 		(&window.Window{}).
 			With(&plot.Contour{
-				Observer: &observer.MatrixToGrid{
-					Observer: &MatrixObserver{},
-				},
-				Palette: palette.Heat(16, 1),
-				Levels:  []float64{-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2},
+				Observer: observer.MatrixToGrid(&MatrixObserver{}, nil, nil),
+				Palette:  palette.Heat(16, 1),
+				Levels:   []float64{-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2},
 			}))
 
 	// Add a termination system that ends the simulation.

--- a/plot/contour_test.go
+++ b/plot/contour_test.go
@@ -1,0 +1,43 @@
+package plot_test
+
+import (
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche-model/system"
+	"github.com/mlange-42/arche-pixel/plot"
+	"github.com/mlange-42/arche-pixel/window"
+	"gonum.org/v1/plot/palette"
+)
+
+func ExampleContour() {
+	// Create a new model.
+	m := model.New()
+
+	// Limit the the simulation speed.
+	m.TPS = 30
+	m.FPS = 0
+
+	// Create a contour plot.
+	m.AddUISystem(
+		(&window.Window{}).
+			With(&plot.Contour{
+				Observer: &observer.MatrixToGrid{
+					Observer: &MatrixObserver{},
+				},
+				Palette: palette.Heat(16, 1),
+				Levels:  []float64{-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2},
+			}))
+
+	// Add a termination system that ends the simulation.
+	m.AddSystem(&system.FixedTermination{
+		Steps: 100,
+	})
+
+	// Run the simulation.
+	// Due to the use of the OpenGL UI system, the model must be run via [github.com/faiface/pixel/pixelgl].
+	// Uncomment the next line. It is commented out as the CI has no display device to test the model run.
+
+	// pixelgl.Run(m.Run)
+
+	// Output:
+}

--- a/plot/field.go
+++ b/plot/field.go
@@ -1,0 +1,109 @@
+package plot
+
+import (
+	"fmt"
+	"image/color"
+
+	"github.com/faiface/pixel"
+	"github.com/faiface/pixel/pixelgl"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche/ecs"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
+	"gonum.org/v1/plot/vg/draw"
+	"gonum.org/v1/plot/vg/vgimg"
+)
+
+// Field plot drawer.
+//
+// Plots a vector field from a GridLayers observer.
+type Field struct {
+	Observer observer.GridLayers // Observers providing field component grids.
+	Labels   Labels              // Labels for plot and axes. Optional.
+	Layers   *[2]int             // Layer indices. Optional, defaults to (0, 1).
+
+	data  plotField
+	scale float64
+}
+
+// Initialize the drawer.
+func (c *Field) Initialize(w *ecs.World, win *pixelgl.Window) {
+	c.Observer.Initialize(w)
+
+	c.data = plotField{
+		GridLayers: c.Observer,
+	}
+
+	if c.Layers == nil {
+		c.Layers = &[2]int{0, 1}
+	}
+	layers := c.Observer.Layers()
+	for _, l := range c.Layers {
+		if layers <= l {
+			panic(fmt.Sprintf("layer index %d out of range", l))
+		}
+	}
+
+	c.scale = calcScaleCorrection()
+}
+
+// Update the drawer.
+func (c *Field) Update(w *ecs.World) {
+	c.Observer.Update(w)
+}
+
+// UpdateInputs handles input events of the previous frame update.
+func (c *Field) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
+
+// Draw the drawer.
+func (c *Field) Draw(w *ecs.World, win *pixelgl.Window) {
+	c.updateData(w)
+
+	width := win.Canvas().Bounds().W()
+	height := win.Canvas().Bounds().H()
+
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	canvas := vgimg.New(vg.Points(width*c.scale)-10, vg.Points(height*c.scale)-10)
+
+	p := plot.New()
+	setLabels(p, c.Labels)
+
+	p.X.Tick.Marker = removeLastTicks{}
+
+	field := plotter.NewField(&c.data)
+
+	p.Add(field)
+
+	win.Clear(color.White)
+	p.Draw(draw.New(canvas))
+
+	img := canvas.Image()
+	picture := pixel.PictureDataFromImage(img)
+
+	sprite := pixel.NewSprite(picture, picture.Bounds())
+	sprite.Draw(win, pixel.IM.Moved(pixel.V(picture.Rect.W()/2.0+5, picture.Rect.H()/2.0+5)))
+}
+
+func (c *Field) updateData(w *ecs.World) {
+	values := c.Observer.Values(w)
+	c.data.XValues = values[c.Layers[0]]
+	c.data.YValues = values[c.Layers[1]]
+}
+
+type plotField struct {
+	observer.GridLayers
+	XValues []float64
+	YValues []float64
+}
+
+func (f *plotField) Vector(c, r int) plotter.XY {
+	w, _ := f.GridLayers.Dims()
+	return plotter.XY{
+		X: f.XValues[r*w+c],
+		Y: f.YValues[r*w+c],
+	}
+}

--- a/plot/field.go
+++ b/plot/field.go
@@ -18,6 +18,8 @@ import (
 // Field plot drawer.
 //
 // Plots a vector field from a GridLayers observer.
+// For large grids, this is relatively slow.
+// Consider using [ImageRGB] instead.
 type Field struct {
 	Observer observer.GridLayers // Observers providing field component grids.
 	Labels   Labels              // Labels for plot and axes. Optional.

--- a/plot/field_test.go
+++ b/plot/field_test.go
@@ -3,16 +3,16 @@ package plot_test
 import (
 	"math"
 
-	"github.com/mazznoer/colorgrad"
+	"github.com/faiface/pixel/pixelgl"
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche-model/system"
 	"github.com/mlange-42/arche-pixel/plot"
 	"github.com/mlange-42/arche-pixel/window"
 	"github.com/mlange-42/arche/ecs"
 )
 
-func ExampleImage() {
-
+func ExampleField() {
 	// Create a new model.
 	m := model.New()
 
@@ -20,16 +20,13 @@ func ExampleImage() {
 	m.TPS = 30
 	m.FPS = 0
 
-	// Create an image plot.
-	// See below for the implementation of the MatrixObserver.
+	// Create a contour plot.
 	m.AddUISystem(
 		(&window.Window{}).
-			With(&plot.Image{
-				Scale:    4,
-				Observer: &MatrixObserver{},
-				Colors:   colorgrad.Inferno(),
-				Min:      -2,
-				Max:      2,
+			With(&plot.Field{
+				Observer: &observer.LayersToGrid{
+					Observer: &FieldObserver{},
+				},
 			}))
 
 	// Add a termination system that ends the simulation.
@@ -41,35 +38,43 @@ func ExampleImage() {
 	// Due to the use of the OpenGL UI system, the model must be run via [github.com/faiface/pixel/pixelgl].
 	// Uncomment the next line. It is commented out as the CI has no display device to test the model run.
 
-	// pixelgl.Run(m.Run)
+	pixelgl.Run(m.Run)
 
 	// Output:
 }
 
-// Example observer, reporting a matrix with z = sin(0.1*i) + sin(0.2*j).
-type MatrixObserver struct {
+type FieldObserver struct {
 	cols   int
 	rows   int
-	values []float64
+	values [][]float64
 }
 
-func (o *MatrixObserver) Initialize(w *ecs.World) {
-	o.cols = 160
-	o.rows = 120
-	o.values = make([]float64, o.cols*o.rows)
+func (o *FieldObserver) Initialize(w *ecs.World) {
+	o.cols = 60
+	o.rows = 40
+	o.values = make([][]float64, 2)
+	for i := 0; i < len(o.values); i++ {
+		o.values[i] = make([]float64, o.cols*o.rows)
+	}
 }
 
-func (o *MatrixObserver) Update(w *ecs.World) {}
+func (o *FieldObserver) Update(w *ecs.World) {}
 
-func (o *MatrixObserver) Dims() (int, int) {
+func (o *FieldObserver) Dims() (int, int) {
 	return o.cols, o.rows
 }
 
-func (o *MatrixObserver) Values(w *ecs.World) []float64 {
-	for idx := 0; idx < len(o.values); idx++ {
+func (o *FieldObserver) Layers() int {
+	return 2
+}
+
+func (o *FieldObserver) Values(w *ecs.World) [][]float64 {
+	ln := len(o.values[0])
+	for idx := 0; idx < ln; idx++ {
 		i := idx % o.cols
 		j := idx / o.cols
-		o.values[idx] = math.Sin(0.1*float64(i)) + math.Sin(0.2*float64(j))
+		o.values[0][idx] = math.Sin(float64(i))
+		o.values[1][idx] = -math.Sin(float64(j))
 	}
 	return o.values
 }

--- a/plot/field_test.go
+++ b/plot/field_test.go
@@ -3,7 +3,6 @@ package plot_test
 import (
 	"math"
 
-	"github.com/faiface/pixel/pixelgl"
 	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche-model/system"
@@ -24,9 +23,7 @@ func ExampleField() {
 	m.AddUISystem(
 		(&window.Window{}).
 			With(&plot.Field{
-				Observer: &observer.LayersToGrid{
-					Observer: &FieldObserver{},
-				},
+				Observer: observer.LayersToLayers(&FieldObserver{}, nil, nil),
 			}))
 
 	// Add a termination system that ends the simulation.
@@ -38,7 +35,7 @@ func ExampleField() {
 	// Due to the use of the OpenGL UI system, the model must be run via [github.com/faiface/pixel/pixelgl].
 	// Uncomment the next line. It is commented out as the CI has no display device to test the model run.
 
-	pixelgl.Run(m.Run)
+	// pixelgl.Run(m.Run)
 
 	// Output:
 }

--- a/plot/heatmap.go
+++ b/plot/heatmap.go
@@ -1,0 +1,99 @@
+package plot
+
+import (
+	"image/color"
+
+	"github.com/faiface/pixel"
+	"github.com/faiface/pixel/pixelgl"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche/ecs"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/palette"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
+	"gonum.org/v1/plot/vg/draw"
+	"gonum.org/v1/plot/vg/vgimg"
+)
+
+// HeatMap plot drawer.
+//
+// Plots a grid as a heatmap image.
+// For large grids, this is relatively slow.
+// Consider using [Image] instead.
+type HeatMap struct {
+	Observer observer.Grid   // Observers providing a Grid for contours.
+	Palette  palette.Palette // Color palette. Optional.
+	Min      float64         // Minimum value for color mapping. Optional.
+	Max      float64         // Maximum value for color mapping. Optional. Is set to 1.0 if both Min and Max are zero.
+	Labels   Labels          // Labels for plot and axes. Optional.
+
+	data  plotGrid
+	scale float64
+}
+
+// Initialize the drawer.
+func (s *HeatMap) Initialize(w *ecs.World, win *pixelgl.Window) {
+	s.Observer.Initialize(w)
+	s.scale = calcScaleCorrection()
+
+	if s.Min == 0 && s.Max == 0 {
+		s.Max = 1
+	}
+}
+
+// Update the drawer.
+func (s *HeatMap) Update(w *ecs.World) {
+	s.Observer.Update(w)
+
+	s.data = plotGrid{
+		Grid: s.Observer,
+	}
+}
+
+// UpdateInputs handles input events of the previous frame update.
+func (s *HeatMap) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
+
+// Draw the drawer.
+func (s *HeatMap) Draw(w *ecs.World, win *pixelgl.Window) {
+	s.updateData(w)
+
+	width := win.Canvas().Bounds().W()
+	height := win.Canvas().Bounds().H()
+
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	c := vgimg.New(vg.Points(width*s.scale)-10, vg.Points(height*s.scale)-10)
+
+	p := plot.New()
+	setLabels(p, s.Labels)
+
+	p.X.Tick.Marker = removeLastTicks{}
+
+	cols := s.Palette.Colors()
+	heat := &plotter.HeatMap{
+		GridXYZ:    &s.data,
+		Palette:    s.Palette,
+		Rasterized: false,
+		Underflow:  cols[0],
+		Overflow:   cols[len(cols)-1],
+		Min:        s.Min,
+		Max:        s.Max,
+	}
+
+	p.Add(heat)
+
+	win.Clear(color.White)
+	p.Draw(draw.New(c))
+
+	img := c.Image()
+	picture := pixel.PictureDataFromImage(img)
+
+	sprite := pixel.NewSprite(picture, picture.Bounds())
+	sprite.Draw(win, pixel.IM.Moved(pixel.V(picture.Rect.W()/2.0+5, picture.Rect.H()/2.0+5)))
+}
+
+func (s *HeatMap) updateData(w *ecs.World) {
+	s.data.Values = s.Observer.Values(w)
+}

--- a/plot/heatmap.go
+++ b/plot/heatmap.go
@@ -32,30 +32,30 @@ type HeatMap struct {
 }
 
 // Initialize the drawer.
-func (s *HeatMap) Initialize(w *ecs.World, win *pixelgl.Window) {
-	s.Observer.Initialize(w)
-	s.scale = calcScaleCorrection()
+func (h *HeatMap) Initialize(w *ecs.World, win *pixelgl.Window) {
+	h.Observer.Initialize(w)
+	h.scale = calcScaleCorrection()
 
-	if s.Min == 0 && s.Max == 0 {
-		s.Max = 1
+	if h.Min == 0 && h.Max == 0 {
+		h.Max = 1
 	}
 }
 
 // Update the drawer.
-func (s *HeatMap) Update(w *ecs.World) {
-	s.Observer.Update(w)
+func (h *HeatMap) Update(w *ecs.World) {
+	h.Observer.Update(w)
 
-	s.data = plotGrid{
-		Grid: s.Observer,
+	h.data = plotGrid{
+		Grid: h.Observer,
 	}
 }
 
 // UpdateInputs handles input events of the previous frame update.
-func (s *HeatMap) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
+func (h *HeatMap) UpdateInputs(w *ecs.World, win *pixelgl.Window) {}
 
 // Draw the drawer.
-func (s *HeatMap) Draw(w *ecs.World, win *pixelgl.Window) {
-	s.updateData(w)
+func (h *HeatMap) Draw(w *ecs.World, win *pixelgl.Window) {
+	h.updateData(w)
 
 	width := win.Canvas().Bounds().W()
 	height := win.Canvas().Bounds().H()
@@ -64,25 +64,25 @@ func (s *HeatMap) Draw(w *ecs.World, win *pixelgl.Window) {
 		return
 	}
 
-	c := vgimg.New(vg.Points(width*s.scale)-10, vg.Points(height*s.scale)-10)
+	c := vgimg.New(vg.Points(width*h.scale)-10, vg.Points(height*h.scale)-10)
 
 	p := plot.New()
-	setLabels(p, s.Labels)
+	setLabels(p, h.Labels)
 
 	p.X.Tick.Marker = removeLastTicks{}
 
-	cols := s.Palette.Colors()
-	heat := &plotter.HeatMap{
-		GridXYZ:    &s.data,
-		Palette:    s.Palette,
+	cols := h.Palette.Colors()
+	heat := plotter.HeatMap{
+		GridXYZ:    &h.data,
+		Palette:    h.Palette,
 		Rasterized: false,
 		Underflow:  cols[0],
 		Overflow:   cols[len(cols)-1],
-		Min:        s.Min,
-		Max:        s.Max,
+		Min:        h.Min,
+		Max:        h.Max,
 	}
 
-	p.Add(heat)
+	p.Add(&heat)
 
 	win.Clear(color.White)
 	p.Draw(draw.New(c))
@@ -94,6 +94,6 @@ func (s *HeatMap) Draw(w *ecs.World, win *pixelgl.Window) {
 	sprite.Draw(win, pixel.IM.Moved(pixel.V(picture.Rect.W()/2.0+5, picture.Rect.H()/2.0+5)))
 }
 
-func (s *HeatMap) updateData(w *ecs.World) {
-	s.data.Values = s.Observer.Values(w)
+func (h *HeatMap) updateData(w *ecs.World) {
+	h.data.Values = h.Observer.Values(w)
 }

--- a/plot/heatmap.go
+++ b/plot/heatmap.go
@@ -34,6 +34,10 @@ type HeatMap struct {
 // Initialize the drawer.
 func (h *HeatMap) Initialize(w *ecs.World, win *pixelgl.Window) {
 	h.Observer.Initialize(w)
+	h.data = plotGrid{
+		Grid: h.Observer,
+	}
+
 	h.scale = calcScaleCorrection()
 
 	if h.Min == 0 && h.Max == 0 {
@@ -44,10 +48,6 @@ func (h *HeatMap) Initialize(w *ecs.World, win *pixelgl.Window) {
 // Update the drawer.
 func (h *HeatMap) Update(w *ecs.World) {
 	h.Observer.Update(w)
-
-	h.data = plotGrid{
-		Grid: h.Observer,
-	}
 }
 
 // UpdateInputs handles input events of the previous frame update.

--- a/plot/heatmap_test.go
+++ b/plot/heatmap_test.go
@@ -1,0 +1,44 @@
+package plot_test
+
+import (
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche-model/system"
+	"github.com/mlange-42/arche-pixel/plot"
+	"github.com/mlange-42/arche-pixel/window"
+	"gonum.org/v1/plot/palette"
+)
+
+func ExampleHeatMap() {
+	// Create a new model.
+	m := model.New()
+
+	// Limit the the simulation speed.
+	m.TPS = 30
+	m.FPS = 0
+
+	// Create a contour plot.
+	m.AddUISystem(
+		(&window.Window{}).
+			With(&plot.HeatMap{
+				Observer: &observer.MatrixToGrid{
+					Observer: &MatrixObserver{},
+				},
+				Palette: palette.Heat(16, 1),
+				Min:     -2,
+				Max:     2,
+			}))
+
+	// Add a termination system that ends the simulation.
+	m.AddSystem(&system.FixedTermination{
+		Steps: 100,
+	})
+
+	// Run the simulation.
+	// Due to the use of the OpenGL UI system, the model must be run via [github.com/faiface/pixel/pixelgl].
+	// Uncomment the next line. It is commented out as the CI has no display device to test the model run.
+
+	// pixelgl.Run(m.Run)
+
+	// Output:
+}

--- a/plot/heatmap_test.go
+++ b/plot/heatmap_test.go
@@ -21,12 +21,10 @@ func ExampleHeatMap() {
 	m.AddUISystem(
 		(&window.Window{}).
 			With(&plot.HeatMap{
-				Observer: &observer.MatrixToGrid{
-					Observer: &MatrixObserver{},
-				},
-				Palette: palette.Heat(16, 1),
-				Min:     -2,
-				Max:     2,
+				Observer: observer.MatrixToGrid(&MatrixObserver{}, nil, nil),
+				Palette:  palette.Heat(16, 1),
+				Min:      -2,
+				Max:      2,
 			}))
 
 	// Add a termination system that ends the simulation.

--- a/plot/image.go
+++ b/plot/image.go
@@ -11,7 +11,11 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
-// Image plot drawer.
+// Image drawer.
+//
+// Draws an image from a Matrix observer.
+// The image is scaled to the canvas extent, with preserved aspect ratio.
+// Does not add plot axes etc.
 type Image struct {
 	Scale    float64            // Spatial scaling: cell size in screen pixels. Optional, default auto.
 	Observer observer.Matrix    // Observer providing 2D matrix or grid data.

--- a/plot/rgb_image.go
+++ b/plot/rgb_image.go
@@ -19,7 +19,7 @@ import (
 type ImageRGB struct {
 	Scale    float64               // Spatial scaling: cell size in screen pixels. Optional, default auto.
 	Observer observer.MatrixLayers // Observer providing data for color channels.
-	Layers   []int                 // Layer indices. Optional, defaults to [0, 1, 2].
+	Layers   []int                 // Layer indices. Optional, defaults to [0, 1, 2]. Use -1 to ignore a channel.
 	Min      []float64             // Minimum value for channel color mapping. Optional, default [0, 0, 0].
 	Max      []float64             // Maximum value for channel color mapping. Optional, default [1, 1, 1].
 	slope    []float64
@@ -39,7 +39,7 @@ func (i *ImageRGB) Initialize(w *ecs.World, win *pixelgl.Window) {
 
 	layers := i.Observer.Layers()
 	for _, l := range i.Layers {
-		if layers <= l {
+		if l >= 0 && layers <= l {
 			panic(fmt.Sprintf("layer index %d out of range", l))
 		}
 	}
@@ -83,7 +83,9 @@ func (i *ImageRGB) Draw(w *ecs.World, win *pixelgl.Window) {
 	values := append([]float64{}, i.Min...)
 	for j := 0; j < i.dataLen; j++ {
 		for i, k := range i.Layers {
-			values[i] = cannels[k][j]
+			if k >= 0 {
+				values[i] = cannels[k][j]
+			}
 		}
 		i.picture.Pix[j] = i.valuesToColor(values[0], values[1], values[2])
 	}

--- a/plot/rgb_image.go
+++ b/plot/rgb_image.go
@@ -10,7 +10,11 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
-// ImageRGB plot drawer.
+// ImageRGB drawer.
+//
+// Draws an image from a Matrix observer per RGB color channel.
+// The image is scaled to the canvas extent, with preserved aspect ratio.
+// Does not add plot axes etc.
 type ImageRGB struct {
 	Scale     float64           // Spatial scaling: cell size in screen pixels. Optional, default auto.
 	Observers []observer.Matrix // Observers for the red, green and blue channel. Elements can be nil.

--- a/plot/rgb_image_test.go
+++ b/plot/rgb_image_test.go
@@ -23,11 +23,11 @@ func ExampleImageRGB() {
 	// See below for the implementation of the CallbackMatrixObserver.
 	m.AddUISystem((&window.Window{}).
 		With(&plot.ImageRGB{
-			Observers: []observer.Matrix{
+			Observer: observer.MatrixToLayers(
 				&CallbackMatrixObserver{Callback: func(i, j int) float64 { return float64(i) / 240 }},
 				&CallbackMatrixObserver{Callback: func(i, j int) float64 { return math.Sin(0.1 * float64(i)) }},
 				&CallbackMatrixObserver{Callback: func(i, j int) float64 { return float64(j) / 160 }},
-			},
+			),
 			Min: []float64{0, 0, 0},
 			Max: []float64{1, 1, 1},
 		}))

--- a/plot/util.go
+++ b/plot/util.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/faiface/pixel/text"
+	"github.com/mlange-42/arche-model/observer"
 	"golang.org/x/image/colornames"
 	"golang.org/x/image/font/basicfont"
 	"gonum.org/v1/plot"
@@ -138,6 +139,16 @@ func (t removeLastTicks) Ticks(min, max float64) []plot.Tick {
 		}
 	}
 	return ticks
+}
+
+type plotGrid struct {
+	observer.Grid
+	Values []float64
+}
+
+func (g *plotGrid) Z(c, r int) float64 {
+	w, _ := g.Dims()
+	return g.Values[r*w+c]
 }
 
 type ringBuffer[T any] struct {


### PR DESCRIPTION
* Drawer `plot.Contour` for plotting grid data as contours
* Drawer `plot.HeatMap` for plotting grid data as heat maps
* Drawer `plot.Field` for plotting 2D vector fields
* Drawer `ImageRGB` uses one `MatrixLayers` observers instead of three `Matrix` observers
* Drawers `plot.ImageRGB` and `plot.Field` can freely assign layers to channels