### PR TITLE
Prepare release v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [[v0.7.0]](https://github.com/mlange-42/arche-pixel/compare/v0.6.0...v0.7.0)
+
+### Breaking changes
+
+* Upgrade to Arche v0.10.0 (#47, #48, #50)
+
 ## [[v0.6.0]](https://github.com/mlange-42/arche-pixel/compare/v0.5.1...v0.6.0)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </a>
 
 </div>
-
+</br>
 <div align="center" width="100%">
 
 ![Screenshot](https://user-images.githubusercontent.com/44003176/232126308-60299642-0490-478d-82a5-48d862da6703.png)  

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mlange-42/arche-pixel
 
 go 1.21
 
-toolchain go1.21.3
+toolchain go1.21.6
 
 require (
 	github.com/gopxl/pixel/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.21.6
 require (
 	github.com/gopxl/pixel/v2 v2.1.0
 	github.com/mazznoer/colorgrad v0.9.1
-	github.com/mlange-42/arche v0.9.1-0.20240118232202-a22df172716d
-	github.com/mlange-42/arche-model v0.5.0
+	github.com/mlange-42/arche v0.10.0
+	github.com/mlange-42/arche-model v0.6.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/image v0.13.0
 	gonum.org/v1/plot v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -42,10 +42,10 @@ github.com/mazznoer/colorgrad v0.9.1 h1:MB80JYVndKWSMEM1beNqnuOowWGhoQc3DXWXkFp6
 github.com/mazznoer/colorgrad v0.9.1/go.mod h1:WX2R9wt9B47+txJZVVpM9LY+LAGIdi4lTI5wIyreDH4=
 github.com/mazznoer/csscolorparser v0.1.2 h1:/UBHuQg792ePmGFzTQAC9u+XbFr7/HzP/Gj70Phyz2A=
 github.com/mazznoer/csscolorparser v0.1.2/go.mod h1:Aj22+L/rYN/Y6bj3bYqO3N6g1dtdHtGfQ32xZ5PJQic=
-github.com/mlange-42/arche v0.9.1-0.20240118232202-a22df172716d h1:TXM9hO4DK3BTxWhcGrE7OMLZlDpwC2cbx7ppqvc8FRU=
-github.com/mlange-42/arche v0.9.1-0.20240118232202-a22df172716d/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
-github.com/mlange-42/arche-model v0.5.0 h1:xDR1sEADfJZbqNXbgBAzpq513LT/6prHY1x6E0/yDBE=
-github.com/mlange-42/arche-model v0.5.0/go.mod h1:j1EsJOoJs931fr2OQLvISaPdXFeCIEXULAYsZiVvdv8=
+github.com/mlange-42/arche v0.10.0 h1:fEFDAYMAnWa+xHc1oq4gVcA4PuEQOCGSRXSKITXawMw=
+github.com/mlange-42/arche v0.10.0/go.mod h1:gJ5J8vBreqrf4TcBomBFPGnWdE5P3qa4LtxYHn1gDcg=
+github.com/mlange-42/arche-model v0.6.0 h1:WA/iZj/vlLs8it4tO18Pk70wIK31GXx7QFNHTWhrCAQ=
+github.com/mlange-42/arche-model v0.6.0/go.mod h1:Di0S5w5ljyZbD4NmcYV7otZ52mm+X71j35VKkf4FC/A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
* upgrade Go toolchain to v1.21.6
* upgrade Arche to v0.10.0
* upgrade to arche-model v0.6.0